### PR TITLE
Fixed animation step count in main.css

### DIFF
--- a/main.css
+++ b/main.css
@@ -89,7 +89,7 @@ footer {
 
 .typeme {
   width: 30ch;
-  animation: typing 2s steps(25), blink .5s step-end infinite alternate;
+  animation: typing 2s steps(30), blink .5s step-end infinite alternate;
   white-space: nowrap;
   overflow: hidden;
   border-right: 10px solid #f2d5cf;


### PR DESCRIPTION
I changed the step count in the typing animation to match the character width of the header (30ch). This ensures the typing animation lines up with the monspace characters and doesn't load half a character or somethiing like that.

Context: 
I stumbled across your repo and found the typing animation really interesting. I looked into your code to try replicating it for one of my sites, however I got confused at the width of the header being 30ch while there being only 25 steps to the animation. This may be intentional and if so forgive me bumping your repo. I thought if you still care about this site you might find this helpful. 