### PR TITLE
fix(css): move background off universal selector

### DIFF
--- a/main.css
+++ b/main.css
@@ -11,8 +11,11 @@
  * */
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap');
 
-* {
+html, body {
   background: #303446;
+}
+
+* {
   font-family: 'IBM Plex Mono', monospace;
   font-weight: 500;
   color: #c6d0f5;


### PR DESCRIPTION
The `* { background: #303446 }` rule applied an opaque background to every element on the page, including inline spans, list items, and paragraphs. 

This triggered a rendering bug in _Firefox_-based browsers (reproduced in _Zen_) where the page rendered as a solid `#303446` rectangle with no visible content.

_Chrome_ handled the same CSS without issue, which is why the bug only surfaced in _Firefox_-derived browsers on the deployed site.

Moving the background declaration to `html, body` (the intended target) removes the opaque backgrounds from inline elements and leaves the visual result unchanged in browsers that were already rendering correctly.